### PR TITLE
fix initialize protocol version negotiation

### DIFF
--- a/server/handle.go
+++ b/server/handle.go
@@ -22,10 +22,11 @@ func (server *Server) handleRequestWithInitialize(ctx context.Context, sessionID
 		return nil, err
 	}
 
-	if _, ok := protocol.SupportedVersion[request.ProtocolVersion]; !ok {
-		return nil, fmt.Errorf("protocol version not supported, supported lastest version is %v", protocol.Version)
-	}
+	// Version negotiation: if client's version is supported, use it; otherwise use server's latest version
 	protocolVersion := request.ProtocolVersion
+	if _, ok := protocol.SupportedVersion[request.ProtocolVersion]; !ok {
+		protocolVersion = protocol.Version
+	}
 
 	if midVar, ok := ctx.Value(transport.SessionIDForReturnKey{}).(*transport.SessionIDForReturn); ok {
 		sessionID = server.sessionManager.CreateSession(ctx)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved protocol version handling: The server now automatically uses the latest supported protocol version if the client's requested version is unsupported, ensuring smoother compatibility without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->